### PR TITLE
ユーザー編集の現在のパスワードを分かりやすくする

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,8 +40,8 @@
         <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "col-sm-12 col-12" %>
       </div>
 
-      <div class="field">
-        <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
+      <div class="field mt-5">
+        <%= f.label :current_password, class: "fw-bold" %> <i class="fw-bold">(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
         <%= f.password_field :current_password, autocomplete: "current-password", class: "col-sm-12 col-12" %>
       </div>
 


### PR DESCRIPTION
現在のパスワードのmargin-topを広げて、ラベルを太字にする
目的：現在のパスワードの入力忘れを少なくする